### PR TITLE
targets/harvey: added old_build option

### DIFF
--- a/targets/harvey/harvey.go
+++ b/targets/harvey/harvey.go
@@ -36,6 +36,9 @@ func init() {
 		log.Fatal(err)
 	}
 
+	if err := internal.Register("old_build", OldBuild{}); err != nil {
+		log.Fatal(err)
+	}
 	if err := internal.Register("data_to_c", DataToC{}); err != nil {
 		log.Fatal(err)
 	}

--- a/targets/harvey/oldbuild.go
+++ b/targets/harvey/oldbuild.go
@@ -1,0 +1,53 @@
+// Copyright 2016 Sevki <s@sevki.org>. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package harvey // import "sevki.org/build/targets/harvey"
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"github.com/nu7hatch/gouuid"
+
+	"sevki.org/build"
+)
+
+type OldBuild struct {
+	Name         string   `old_build:"name"`
+	Dependencies []string `old_build:"deps"`
+	Package      string   `old_build:"package"`
+}
+
+func (ob *OldBuild) GetName() string {
+	return ob.Name
+}
+
+func (ob *OldBuild) GetDependencies() []string {
+	return ob.Dependencies
+}
+
+func (s *OldBuild) Hash() []byte {
+	h := sha1.New()
+	u, _ := uuid.NewV4()
+	io.WriteString(h, u.String())
+	return []byte{}
+}
+
+func oldbuild() string {
+	return path.Join(os.Getenv("HARVEY"), "util/build")
+}
+func (s *OldBuild) Build(c *build.Context) error {
+	params := []string{s.Package}
+
+	if err := c.Exec(oldbuild(), nil, params); err != nil {
+		return fmt.Errorf(err.Error())
+	}
+	return nil
+}
+func (s *OldBuild) Installs() map[string]string {
+	return nil
+}


### PR DESCRIPTION
when I build this with

```
ARCH=amd64 HARVEY=`pwd` build -v :all
```

it can't find the build.json but I don't think
it's going to be a lot harder to get it working fully

r: @rminnich

Signed-off-by: Sevki s@sevki.org
