### PR TITLE
builder: install option now copies files contents instead of symlinking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
-  - 1.5
-  - 1.6
+  - 1.7
   - tip
 env:
   - "PATH=/home/travis/gopath/bin:$PATH"

--- a/build.go
+++ b/build.go
@@ -14,8 +14,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-
-	"sevki.org/build/util"
 )
 
 // Target defines the interface that rules must implement for becoming build targets.
@@ -48,9 +46,6 @@ func NewContext(dir string) *Context {
 		logger: log.New(&buf, "", log.Lmicroseconds),
 		buf:    &buf,
 	}
-}
-func Getenv(s string) string {
-	return util.Getenv(s)
 }
 func (c *Context) Stdout() io.Reader {
 	return c.buf

--- a/builder/coordinator.go
+++ b/builder/coordinator.go
@@ -229,15 +229,7 @@ func (b *Builder) visit(n *Node) {
 }
 
 func install(job *Node) error {
-	buildOut := ""
-	if build.Getenv("BUILD_OUT") != "" {
-		buildOut = build.Getenv("BUILD_OUT")
-	} else {
-		buildOut = filepath.Join(
-			util.GetProjectPath(),
-			"build_out",
-		)
-	}
+	buildOut := util.BuildOut()
 	os.RemoveAll(buildOut)
 	if err := os.MkdirAll(
 		buildOut,

--- a/targets/cc/cc.go
+++ b/targets/cc/cc.go
@@ -13,8 +13,8 @@ import (
 
 	"os"
 
-	"sevki.org/build"
 	"sevki.org/build/internal"
+	"sevki.org/build/util"
 )
 
 var (
@@ -30,13 +30,13 @@ func init() {
 	CCENV = append(CCENV, fmt.Sprintf("%s=%s", "C_INCLUDE_PATH", "include"))
 	CCENV = append(CCENV, fmt.Sprintf("%s=%s", "LIBRARY_PATH", "lib"))
 
-	if cc = build.Getenv("CC"); cc == "" {
+	if cc = util.Getenv("CC"); cc == "" {
 		cc = "CC"
 	}
-	if ld = build.Getenv("LD"); ld == "" {
+	if ld = util.Getenv("LD"); ld == "" {
 		ld = "ld"
 	}
-	if ar = build.Getenv("AR"); ar == "" {
+	if ar = util.Getenv("AR"); ar == "" {
 		ar = "ar"
 	}
 
@@ -57,7 +57,7 @@ func init() {
 }
 
 func Compiler() string {
-	if tpfx := build.Getenv("TOOLPREFIX"); tpfx == "" {
+	if tpfx := util.Getenv("TOOLPREFIX"); tpfx == "" {
 		return cc
 	} else {
 		return fmt.Sprintf("%s%s", tpfx, cc)
@@ -65,14 +65,14 @@ func Compiler() string {
 }
 
 func Archiver() string {
-	if tpfx := build.Getenv("TOOLPREFIX"); tpfx == "" {
+	if tpfx := util.Getenv("TOOLPREFIX"); tpfx == "" {
 		return ar
 	} else {
 		return fmt.Sprintf("%s%s", tpfx, ar)
 	}
 }
 func Linker() string {
-	if tpfx := build.Getenv("TOOLPREFIX"); tpfx == "" {
+	if tpfx := util.Getenv("TOOLPREFIX"); tpfx == "" {
 		return ld
 	} else {
 		return fmt.Sprintf("%s%s", tpfx, ld)
@@ -81,12 +81,13 @@ func Linker() string {
 
 // Had to be done
 func Stripper() string {
-	if tpfx := build.Getenv("TOOLPREFIX"); tpfx == "" {
+	if tpfx := util.Getenv("TOOLPREFIX"); tpfx == "" {
 		return "strip"
 	} else {
 		return fmt.Sprintf("%s%s", tpfx, "strip")
 	}
 }
+
 type CompilerFlags []string
 
 type Includes []string

--- a/targets/harvey/harvey.go
+++ b/targets/harvey/harvey.go
@@ -36,6 +36,9 @@ func init() {
 		log.Fatal(err)
 	}
 
+	if err := internal.Register("old_build", OldBuild{}); err != nil {
+		log.Fatal(err)
+	}
 	if err := internal.Register("data_to_c", DataToC{}); err != nil {
 		log.Fatal(err)
 	}

--- a/targets/harvey/objcopy.go
+++ b/targets/harvey/objcopy.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"sevki.org/build"
+	"sevki.org/build/util"
 )
 
 type ObjCopy struct {
@@ -38,7 +39,7 @@ func (oc *ObjCopy) Hash() []byte {
 
 // Had to be done
 func Copier() string {
-	if tpfx := build.Getenv("TOOLPREFIX"); tpfx == "" {
+	if tpfx := util.Getenv("TOOLPREFIX"); tpfx == "" {
 		return "objcopy"
 	} else {
 		return fmt.Sprintf("%s%s", tpfx, "objcopy")

--- a/targets/harvey/oldbuild.go
+++ b/targets/harvey/oldbuild.go
@@ -1,0 +1,53 @@
+// Copyright 2016 Sevki <s@sevki.org>. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package harvey // import "sevki.org/build/targets/harvey"
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"github.com/nu7hatch/gouuid"
+
+	"sevki.org/build"
+)
+
+type OldBuild struct {
+	Name         string   `old_build:"name"`
+	Dependencies []string `old_build:"deps"`
+	Package      string   `old_build:"package"`
+}
+
+func (ob *OldBuild) GetName() string {
+	return ob.Name
+}
+
+func (ob *OldBuild) GetDependencies() []string {
+	return ob.Dependencies
+}
+
+func (s *OldBuild) Hash() []byte {
+	h := sha1.New()
+	u, _ := uuid.NewV4()
+	io.WriteString(h, u.String())
+	return []byte{}
+}
+
+func oldbuild() string {
+	return path.Join(os.Getenv("HARVEY"), "util/build")
+}
+func (s *OldBuild) Build(c *build.Context) error {
+	params := []string{s.Package}
+
+	if err := c.Exec(oldbuild(), nil, params); err != nil {
+		return fmt.Errorf(err.Error())
+	}
+	return nil
+}
+func (s *OldBuild) Installs() map[string]string {
+	return nil
+}

--- a/targets/harvey/strip.go
+++ b/targets/harvey/strip.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"sevki.org/build"
+	"sevki.org/build/util"
 )
 
 type Strip struct {
@@ -34,7 +35,7 @@ func (s *Strip) Hash() []byte {
 
 // Had to be done
 func Stripper() string {
-	if tpfx := build.Getenv("TOOLPREFIX"); tpfx == "" {
+	if tpfx := util.Getenv("TOOLPREFIX"); tpfx == "" {
 		return "strip"
 	} else {
 		return fmt.Sprintf("%s%s", tpfx, "strip")


### PR DESCRIPTION
you can also set the build_out folder by setting the BUILD_OUT
env var from either command line or by editing the .build file

Signed-off-by: Sevki s@sevki.org
