### PR TITLE
Make progressbar be the alternative

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -36,7 +36,7 @@ If you are in a subfoler we will traverse the parent folders until we hit a .git
 `
 )
 var (
-	verbose = flag.Bool("v", false, "more verbose output")
+	progressbar = flag.Bool("p", false, "Show a progress bar (note: it can hide errors)")
 )
 
 func main() {
@@ -135,14 +135,14 @@ func execute(t string) {
 		os.Exit(1)
 	}()
 
-	go term.Listen(c.Updates, cpus, *verbose)
+	go term.Listen(c.Updates, cpus, *progressbar)
 	go term.Run(done)
 
 	go c.Execute(time.Second, cpus)
 	for {
 		select {
 		case done := <-c.Done:
-			if *verbose {
+			if !*progressbar {
 				doneMessage(done.Url.String())
 			}
 			if done.IsRoot {

--- a/term/term.go
+++ b/term/term.go
@@ -19,7 +19,7 @@ var (
 	statuses    map[int]builder.Update
 	worderCount int
 	stated      time.Time
-	verbose     bool
+	progressbar     bool
 	exit        bool
 )
 
@@ -30,9 +30,9 @@ func init() {
 func Exit() {
 	exit = true
 }
-func Listen(updates chan builder.Update, i int, v bool) {
+func Listen(updates chan builder.Update, i int, p bool) {
 	worderCount = i
-	verbose = v
+	progressbar = p
 	statuses = make(map[int]builder.Update)
 	for k := 0; k < i; k++ {
 		statuses[k] = builder.Update{
@@ -56,7 +56,7 @@ func failMessage(s string) {
 
 func Run(done chan bool) {
 
-	if !verbose {
+	if progressbar {
 		tm.Clear() // Clear current screen
 	}
 
@@ -65,7 +65,7 @@ func Run(done chan bool) {
 
 	for {
 		time.Sleep(time.Millisecond)
-		if !verbose {
+		if progressbar {
 			tm.MoveCursor(1, 1)
 			header := fmt.Sprintf("Building (%s)",
 				time.Since(stated).String(),
@@ -74,7 +74,7 @@ func Run(done chan bool) {
 		}
 
 		for worker, update := range statuses {
-			if !verbose {
+			if progressbar {
 				tm.MoveCursor(worker+2, 1)
 			}
 
@@ -103,12 +103,12 @@ func Run(done chan bool) {
 			}
 
 		}
-		if !verbose {
+		if progressbar {
 			tm.Flush() // Call it every time at the end of rendering
 		}
 		if exit {
 			if failed {
-				if !verbose {
+				if progressbar {
 					tm.MoveCursor(worderCount+2, 1)
 					failMessage(failedUpdate.Target)
 					tm.Flush()
@@ -121,7 +121,7 @@ func Run(done chan bool) {
 	}
 }
 func termPrintln(s string) {
-	if verbose {
+	if !progressbar {
 		//		log.Println(s)
 		return
 	}


### PR DESCRIPTION
The progressbar is kind of nice but should not be
the default; it hides errors and is not usable at all
in, e.g., emacs compilation buffers.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>