### PR TITLE
postprocessor: expand envinroment variables in paths

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -167,7 +167,7 @@ func (b *Builder) Add(t string) *Node {
 func (n *Node) HashNode() []byte {
 
 	// node hashes should not change after a build,
-	// they should be deterministic, therefore they should and can be cached.
+	// they should be deterministic, therefore they can and should be cached.
 	if len(n.hash) > 0 {
 		return n.hash
 	}

--- a/postprocessor/postprocessor.go
+++ b/postprocessor/postprocessor.go
@@ -8,6 +8,7 @@ package postprocessor
 import (
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -125,13 +126,16 @@ func (pp *PostProcessor) absPath(s string) string {
 	if len(s) < 2 {
 		log.Fatalf("%s is invalid", s)
 	}
+	var r string
 	switch {
 	case s[:2] == "//":
-		return filepath.Join(pp.projectPath, strings.Trim(s, "//"))
+		r = filepath.Join(pp.projectPath, strings.Trim(s, "//"))
 	default:
 		if filepath.IsAbs(s) {
 			return s
 		}
-		return filepath.Join(pp.projectPath, pp.packagePath, s)
+		r = filepath.Join(pp.projectPath, pp.packagePath, s)
 	}
+	r = os.Expand(r, util.Getenv)
+	return r
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -481,7 +481,7 @@ func (p *Processor) env(f *ast.Func) string {
 	if len(f.AnonParams) != 1 {
 		return ""
 	}
-	return os.Getenv(f.AnonParams[0].(string))
+	return util.Getenv(f.AnonParams[0].(string))
 }
 
 func (p *Processor) version(f *ast.Func) string {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -242,11 +242,14 @@ func (p *Processor) runFunc(f *ast.Func) {
 }
 
 func (p *Processor) absPath(s string) string {
+	var r string
 	if strings.TrimLeft(s, "//") != s {
-		return filepath.Join(util.GetProjectPath(), strings.Trim(s, "//"))
+		r = filepath.Join(util.GetProjectPath(), strings.Trim(s, "//"))
 	} else {
-		return filepath.Join(p.parser.Path, s)
+		r = filepath.Join(p.parser.Path, s)
 	}
+	r = os.Expand(r, util.Getenv)
+	return r
 }
 
 func (p *Processor) makeTarget(f *ast.Func) (build.Target, error) {
@@ -305,7 +308,7 @@ func (p *Processor) makeTarget(f *ast.Func) (build.Target, error) {
 		}
 	}
 
-	//BUG(sevki): this is a very hacky way of doing this but it seems to be safer don't mind.
+	//BUG(sevki): this is a very hacky way of doing this but it seems to be safer.
 	var bytz []byte
 	buf := bytes.NewBuffer(bytz)
 


### PR DESCRIPTION
this will expand envinroment variables in paths.

because of how this behaviour is defined in go

$ARCHcpu.c is expanded to .c so to be on the safe side
always use ${ARCH}cpu.c convention which expands correctly
to amd64cpu.c

closes #44

Signed-off-by: Sevki <s@sevki.org>