### PR TITLE
processer: built in printf function

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -267,12 +267,27 @@ func lexComment(l *Lexer) stateFn {
 	return lexAny
 }
 
+func (l *Lexer) peekIgnoreWhiteSpace() rune {
+	spaces := 0
+	for isSpace(l.peek()) {
+		spaces++
+		l.next()
+	}
+	t := l.peek()
+
+	for ; spaces != 0; spaces-- {
+		l.backup()
+	}
+	return t
+}
+
 // lexSpace scans a run of space characters.
 // One space has already been seen.
 func lexAlphaNumeric(l *Lexer) stateFn {
 	for isAlphaNumeric(l.peek()) {
 		l.next()
 	}
+
 	// Do we need this special case? it certainly makes
 	// stuff easier but variables don't have this luxury
 	// should variables start with let or var?
@@ -281,6 +296,10 @@ func lexAlphaNumeric(l *Lexer) stateFn {
 		l.emit(token.Func)
 		return lexAny
 	default:
+		if l.peekIgnoreWhiteSpace() == '=' {
+			l.emit(token.Name)
+			return lexAny
+		}
 		switch l.input[l.start:l.pos] {
 		case "for":
 			l.emit(token.For)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -91,14 +91,14 @@ func parseDecl(p *Parser) stateFn {
 	switch p.peek().Type {
 	case token.Func:
 		return parseFunc
-	case token.String:
+	case token.Name:
 		return parseVar
 	case token.LeftBrac:
 		return parseLoop
 	case token.EOF:
 		return nil
 	default:
-		p.expects(p.peek(), token.Func, token.String, token.LeftBrac, token.EOF)
+		p.expects(p.peek(), token.Func, token.Name, token.LeftBrac, token.EOF)
 		return nil
 	}
 }
@@ -163,7 +163,7 @@ func parseFunc(p *Parser) stateFn {
 func parseVar(p *Parser) stateFn {
 	t := p.next()
 
-	if err := p.expects(t, token.String); err != nil {
+	if err := p.expects(t, token.Name); err != nil {
 		p.Error = err
 		return nil
 	}
@@ -352,13 +352,13 @@ END:
 func (p *Parser) consumeParams(f *ast.Func) error {
 	for {
 		switch p.peek().Type {
-		case token.Quote, token.LeftBrac, token.Func:
+		case token.Quote, token.LeftBrac, token.Func, token.String:
 			if n, err := p.consumeNode(); err != nil {
 				return err
 			} else {
 				f.AnonParams = append(f.AnonParams, n)
 			}
-		case token.String:
+		case token.Name:
 			t := p.next()
 			if f.Params == nil {
 				f.Params = make(map[string]interface{})
@@ -397,8 +397,8 @@ func (p *Parser) consumeParams(f *ast.Func) error {
 		} else {
 			return err
 		}
-
 	}
+
 }
 func (p *Parser) consumeMap() (*ast.Map, error) {
 	t := p.next()
@@ -435,6 +435,7 @@ func (p *Parser) consumeMap() (*ast.Map, error) {
 }
 func (p *Parser) consumeFunc() (*ast.Func, error) {
 	t := p.next()
+
 	if err := p.expects(t, token.Func); err != nil {
 		return nil, err
 	}
@@ -447,11 +448,11 @@ func (p *Parser) consumeFunc() (*ast.Func, error) {
 		Line:  t.Line,
 		Index: t.Start,
 	}
-
 	t = p.next()
 	if err := p.expects(t, token.LeftParen); err != nil {
 		return nil, err
 	}
+
 	p.consumeParams(&f)
 	return &f, nil
 }

--- a/parser/util.go
+++ b/parser/util.go
@@ -17,6 +17,9 @@ import (
 	"bldy.build/build/util"
 )
 
+func init() {
+	log.SetPrefix("parser: ")
+}
 func caller() (call string, file string, line int) {
 	var caller uintptr
 	caller, file, line, _ = runtime.Caller(2)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -333,6 +333,8 @@ func (p *Processor) funcReturns(f *ast.Func) interface{} {
 	switch f.Name {
 	case "glob":
 		return p.glob(f)
+	case "printf":
+		return p.printf(f)
 	case "version":
 		return p.version(f)
 	case "addition":
@@ -418,6 +420,15 @@ func (p *Processor) sliceString(f *ast.Func, s string) interface{} {
 		return nil
 	}
 }
+func (p *Processor) printf(f *ast.Func) string {
+	format := f.AnonParams[0]
+	switch format.(type) {
+	case string:
+		return fmt.Sprintf(format.(string), f.AnonParams[1:]...)
+	}
+
+	return "Invalid formatting"
+}
 func (p *Processor) glob(f *ast.Func) []string {
 	wd := p.parser.Path
 	if !filepath.IsAbs(wd) {
@@ -485,7 +496,6 @@ func (p *Processor) env(f *ast.Func) string {
 }
 
 func (p *Processor) version(f *ast.Func) string {
-
 	if out, err := exec.Command("git",
 		"--git-dir="+util.GetGitDir(p.parser.Path)+".git",
 		"describe",

--- a/token/token.go
+++ b/token/token.go
@@ -48,6 +48,7 @@ const (
 	Func
 	For
 	In
+	Name
 )
 
 func (t Token) String() string {

--- a/token/type_string.go
+++ b/token/type_string.go
@@ -4,9 +4,9 @@ package token
 
 import "fmt"
 
-const _Type_name = "EOFErrorNewlineStringSpaceIntFloatHexLeftCurlyRightCurlyLeftParenRightParenLeftBracRightBracQuoteEqualColonCommaSemicolonPeriodCommentPlusPipeElipsisTrueFalseMultiLineStringTargetDeclFuncForIn"
+const _Type_name = "EOFErrorNewlineStringSpaceIntFloatHexLeftCurlyRightCurlyLeftParenRightParenLeftBracRightBracQuoteEqualColonCommaSemicolonPeriodCommentPlusPipeElipsisTrueFalseMultiLineStringTargetDeclFuncForInName"
 
-var _Type_index = [...]uint8{0, 3, 8, 15, 21, 26, 29, 34, 37, 46, 56, 65, 75, 83, 92, 97, 102, 107, 112, 121, 127, 134, 138, 142, 149, 153, 158, 173, 183, 187, 190, 192}
+var _Type_index = [...]uint8{0, 3, 8, 15, 21, 26, 29, 34, 37, 46, 56, 65, 75, 83, 92, 97, 102, 107, 112, 121, 127, 134, 138, 142, 149, 153, 158, 173, 183, 187, 190, 192, 196}
 
 func (i Type) String() string {
 	if i < 0 || i >= Type(len(_Type_index)-1) {


### PR DESCRIPTION
added a  built-in printf function for nice looking concatenations 

which exposed a bunch of errors in the parser and lexer which 
led me to introduce the name token. 
if a string token is followed by a string it will be called a
name token, this makes parsing things a lot easier with a lot less
corner cases

Signed-off-by: Sevki <s@sevki.org>