### PR TITLE
postprocessor: add expand tag

### DIFF
--- a/targets/harvey/move.go
+++ b/targets/harvey/move.go
@@ -11,19 +11,16 @@ import (
 type Move struct {
 	Name         string            `move:"name"`
 	Dependencies []string          `move:"deps"`
-	Exports      map[string]string `move:"installs"`
+	Exports      map[string]string `move:"installs" build:"expand"`
 }
 
 func (m *Move) Hash() []byte {
-
 	h := sha1.New()
-
 	io.WriteString(h, m.Name)
 	return h.Sum(nil)
 }
 
 func (m *Move) Build(c *build.Context) error {
-
 	return nil
 }
 


### PR DESCRIPTION
this tag doesn't relativize path strings but it does expand env
vars in strings

	Exports map[string]string `move:"installs" build:"expand"`

add this tag to variables in targets that you want envinroment
variables expanded in.

Signed-off-by: Sevki <s@sevki.org>