### PR TITLE
builder: builder now treats group target as a special case

### DIFF
--- a/builder/coordinator.go
+++ b/builder/coordinator.go
@@ -43,7 +43,6 @@ func (b *Builder) Execute(d time.Duration, r int) {
 
 	for i := 0; i < r; i++ {
 		go b.work(i)
-
 	}
 
 	go func() {
@@ -84,7 +83,6 @@ func (b *Builder) build(n *Node) (err error) {
 		if e.Status == Fail {
 			buildErr = fmt.Errorf("dependency %s failed to build", e.Target.GetName())
 		} else {
-
 			for dst, src := range e.Target.Installs() {
 
 				target := filepath.Base(dst)

--- a/targets/build/group.go
+++ b/targets/build/group.go
@@ -9,6 +9,7 @@ import "bldy.build/build"
 type Group struct {
 	Name         string   `group:"name"`
 	Dependencies []string `group:"deps"`
+	Exports      map[string]string
 }
 
 func (g *Group) Hash() []byte {
@@ -17,7 +18,6 @@ func (g *Group) Hash() []byte {
 }
 
 func (g *Group) Build(c *build.Context) error {
-
 	return nil
 }
 
@@ -29,5 +29,5 @@ func (g *Group) GetDependencies() []string {
 	return g.Dependencies
 }
 func (g *Group) Installs() map[string]string {
-	return nil
+	return g.Exports
 }


### PR DESCRIPTION
It will run trough all the other targets Installs and copy them to
the group.

Signed-off-by: Sevki <s@sevki.org>