### PR TITLE
project: copy to root

### DIFF
--- a/project/project.go
+++ b/project/project.go
@@ -43,7 +43,7 @@ func RelPPath(p string) string {
 }
 
 func BuildOut() string {
-	if *copyToRoot || Getenv("COPYTOROOT") == "true" {
+	if *copyToRoot  {
 		return Root()
 	}
 

--- a/project/project.go
+++ b/project/project.go
@@ -5,6 +5,7 @@
 package project // import "bldy.build/build/project"
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -19,6 +20,8 @@ var (
 	file ini.File
 
 	pp = ""
+
+	copyToRoot = flag.Bool("r", false, "set root of the project as build out. should not be used with watch")
 )
 
 func init() {
@@ -40,7 +43,11 @@ func RelPPath(p string) string {
 }
 
 func BuildOut() string {
-	if os.Getenv("BUILD_OUT") != "" {
+	if *copyToRoot || Getenv("COPYTOROOT") == "true" {
+		return Root()
+	}
+
+	if Getenv("BUILD_OUT") != "" {
 		return Getenv("BUILD_OUT")
 	} else {
 		return filepath.Join(


### PR DESCRIPTION
with this change bldy copy things to root of the project instead
of build out. this was possible before with by manually setting
the BUILD_OUT environment variable but now it can either
be triggered by

	bldy -r kernel

`-r` flag now stands for copytoRoot.
by setting COPYTOROOT=true in either bldy.cfg in the root of the
project or as an environment variable.

closes #57

Signed-off-by: Sevki <s@sevki.org>