### PR TITLE
project: remove the "should not be used with watch" statement

### DIFF
--- a/project/project.go
+++ b/project/project.go
@@ -21,7 +21,7 @@ var (
 
 	pp = ""
 
-	copyToRoot = flag.Bool("r", false, "set root of the project as build out. should not be used with watch")
+	copyToRoot = flag.Bool("r", false, "set root of the project as build out")
 )
 
 func init() {
@@ -43,7 +43,7 @@ func RelPPath(p string) string {
 }
 
 func BuildOut() string {
-	if *copyToRoot  {
+	if *copyToRoot {
 		return Root()
 	}
 


### PR DESCRIPTION
It is a generic problem that every build tool and compiler has
If you are watching a directory for changes to recompile a project
and your compiler writes to that directory the changes will cause
an infinite loop. But that certainly applies for any dir watcher
and compiler/build tool. So specifically mentioning it here makes
no sense and causes panic.

Signed-off-by: Sevki <s@sevki.org>