### PR TITLE
harvey: mksys fix the 'missing =' warning for clang

### DIFF
--- a/targets/harvey/mksys.go
+++ b/targets/harvey/mksys.go
@@ -317,7 +317,7 @@ const(
 {{ range . }}extern void {{ .Sysname }}(Ar0*, ...);
 {{ end }}
 Systab systab[] = {
-{{ range . }}[{{ .Define }}] { "{{ .Name }}", {{ .Sysname }}, {{ .Fudge }} },
+{{ range . }}[{{ .Define }}] = { "{{ .Name }}", {{ .Sysname }}, {{ .Fudge }} },
 {{ end }}
 };
 int nsyscall = nelem(systab);


### PR DESCRIPTION
without this harvey cannot be built with clang

Signed-off-by: Sevki <s@sevki.org>