### PR TITLE
executor: executor moved to it's own package

### DIFF
--- a/build.go
+++ b/build.go
@@ -6,138 +6,17 @@
 package build
 
 import (
-	"bytes"
-	"context"
-	"flag"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"time"
-
+	"bldy.build/build/executor"
 	"bldy.build/build/url"
-)
-
-var (
-	printenv = flag.Bool("e", false, "prints envinroment variables into the log")
 )
 
 // Target defines the interface that rules must implement for becoming build targets.
 type Target interface {
 	GetName() string
 	GetDependencies() []string
-
 	Hash() []byte
-	Build(*Executor) error
+	Build(*executor.Executor) error
 	Installs() map[string]string
-}
-
-// Runner defines the envinroment in which a target will be built, it
-// provide helper functions for shelling out without having to worry
-// about stdout or stderr outputs.
-type Executor struct {
-	ctx context.Context
-	wd  string
-	run []*Run
-	log []fmt.Stringer
-}
-
-func (e *Executor) Context() context.Context {
-	return e.ctx
-}
-
-type Run struct {
-	At     time.Time
-	Cmd    string
-	Args   []string
-	Output []byte
-	Env    []string
-	Err    error
-}
-
-func (r *Run) String() string {
-	buf := bytes.Buffer{}
-	if *printenv {
-		buf.WriteString("envinroment variables: " + strings.Join(r.Env, "\n"))
-	}
-	buf.WriteString(strings.Join(append([]string{r.Cmd}, r.Args...), "\n"))
-
-	buf.WriteString("\n")
-	buf.Write(r.Output)
-	return string(buf.String())
-}
-
-type Message string
-
-func (m Message) String() string {
-	return string(m)
-}
-func (e *Executor) RunCmds() []*Run {
-	return e.run
-}
-
-func (e *Executor) Log() []fmt.Stringer {
-	return e.log
-}
-
-// NewContext initializes and returns a new build.Context
-func NewRunner(ctx context.Context, dir string) *Executor {
-	return &Executor{
-		wd:  dir,
-		ctx: ctx,
-	}
-}
-
-func (e *Executor) Printf(format string, v ...interface{}) {
-	e.log = append(e.log, Message(fmt.Sprintf(format, v...)))
-}
-
-func (e *Executor) Println(v ...interface{}) {
-	e.log = append(e.log, Message(fmt.Sprintln(v...)))
-}
-
-// Exec executes a command writing it's outputs to the context
-func (e *Executor) Exec(cmd string, env, args []string) error {
-	run := Run{
-		At:   time.Now(),
-		Cmd:  cmd,
-		Args: args,
-		Env:  env,
-	}
-	x := exec.CommandContext(e.ctx, cmd, args...)
-	x.Dir = e.wd
-	x.Env = env
-	run.Output, run.Err = x.CombinedOutput()
-	e.run = append(e.run, &run)
-	e.log = append(e.log, &run)
-	return run.Err
-}
-
-// Run executes a command writing it's outputs to the context
-func (e *Executor) Run(ctx context.Context, cmd string, env, params []string) *exec.Cmd {
-	x := exec.CommandContext(ctx, cmd, params...)
-
-	x.Dir = e.wd
-	x.Env = env
-	return x
-}
-
-// Create creates and returns a new file with the given name in the context
-func (r *Executor) Create(name string) (*os.File, error) {
-	return os.Create(filepath.Join(r.wd, name))
-}
-
-// Open creates and returns a new file with the given name in the context
-func (r *Executor) Open(name string) (*os.File, error) {
-	if filepath.IsAbs(name) {
-		return os.Open(name)
-	}
-	return os.Open(filepath.Join(r.wd, name))
-}
-
-func (r *Executor) Mkdir(name string) error {
-	return os.MkdirAll(filepath.Join(r.wd, name), os.ModeDir|os.ModePerm)
 }
 
 // VM seperate the parsing and evauluating targets logic from rest of bldy

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -16,6 +16,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"bldy.build/build/executor"
+
 	"sevki.org/pqueue"
 
 	"io/ioutil"
@@ -154,7 +156,7 @@ func (b *Builder) build(ctx context.Context, n *graph.Node) (err error) {
 		}
 	}
 
-	runner := build.NewRunner(ctx, outDir)
+	runner := executor.New(ctx, outDir)
 	n.Start = time.Now().UnixNano()
 
 	buildErr = n.Target.Build(runner)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1,0 +1,157 @@
+// Copyright 2017 Sevki <s@sevki.org>. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package executor // import "bldy.build/build/executor"
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+var (
+	printenv = flag.Bool("e", false, "prints envinroment variables into the log")
+)
+
+// Executor defines the envinroment in which a target will be built, it
+// provide helper functions for shelling out without having to worry
+// about stdout or stderr outputs.
+type Executor struct {
+	ctx context.Context
+	wd  string
+	run []*Run
+	log []fmt.Stringer
+}
+
+// Context returns the context that's attached to the Executor
+func (e *Executor) Context() context.Context {
+	return e.ctx
+}
+
+// Run defines the execution step
+type Run struct {
+	At     time.Time
+	Cmd    string
+	Args   []string
+	Output []byte
+	Env    []string
+	Err    error
+}
+
+func (r *Run) String() string {
+	buf := bytes.Buffer{}
+	if *printenv {
+		buf.WriteString("envinroment variables: " + strings.Join(r.Env, "\n"))
+	}
+	buf.WriteString(strings.Join(append([]string{r.Cmd}, r.Args...), "\n"))
+
+	buf.WriteString("\n")
+	buf.Write(r.Output)
+	return string(buf.String())
+}
+
+// Message defines a log Item in the message
+type Message string
+
+func (m Message) String() string {
+	return string(m)
+}
+
+// RunCmds commands returns the commands that ran
+func (e *Executor) RunCmds() []*Run {
+	return e.run
+}
+
+// Log returns the logs
+func (e *Executor) Log() []fmt.Stringer {
+	return e.log
+}
+
+// New initializes and returns a new executor.Executor
+func New(ctx context.Context, dir string) *Executor {
+	return &Executor{
+		wd:  dir,
+		ctx: ctx,
+	}
+}
+
+// Printf wraps sprintf for log items
+func (e *Executor) Printf(format string, v ...interface{}) {
+	e.log = append(e.log, Message(fmt.Sprintf(format, v...)))
+}
+
+// Println wraps sprintf for log items
+func (e *Executor) Println(v ...interface{}) {
+	e.log = append(e.log, Message(fmt.Sprintln(v...)))
+}
+
+// Exec executes a command writing it's outputs to the context
+func (e *Executor) Exec(cmd string, env, args []string) error {
+
+	run := Run{
+		At:   time.Now(),
+		Cmd:  cmd,
+		Args: args,
+		Env:  env,
+	}
+	x := exec.CommandContext(e.ctx, cmd, args...)
+	x.Dir = e.wd
+	x.Env = env
+	run.Output, run.Err = x.CombinedOutput()
+	e.run = append(e.run, &run)
+	e.log = append(e.log, &run)
+	return run.Err
+}
+
+// Run executes a command writing it's outputs to the context
+func (e *Executor) Run(ctx context.Context, cmd string, env, params []string) *exec.Cmd {
+	x := exec.CommandContext(ctx, cmd, params...)
+
+	x.Dir = e.wd
+	x.Env = env
+	return x
+}
+
+// Create creates and returns a new file with the given name in the context
+func (e *Executor) Create(name string) (*os.File, error) {
+	return os.Create(filepath.Join(e.wd, name))
+}
+
+// Open creates and returns a new file with the given name in the context
+func (e *Executor) Open(name string) (*os.File, error) {
+	if filepath.IsAbs(name) {
+		return os.Open(name)
+	}
+	return os.Open(filepath.Join(e.wd, name))
+}
+
+// Mkdir creates a folder in the executor
+func (e *Executor) Mkdir(name string) error {
+	return os.MkdirAll(filepath.Join(e.wd, name), os.ModeDir|os.ModePerm)
+}
+
+// Status represents a nodes status.
+type Status int
+
+const (
+	// Success is success
+	Success Status = iota
+	// Fail is a failed job
+	Fail
+	// Pending is a pending job
+	Pending
+	// Started is a started job
+	Started
+	// Fatal is a fatal crash
+	Fatal
+	// Warning is a job that has warnings
+	Warning
+	// Building is a job that's being built
+	Building
+)

--- a/racy/racy_test.go
+++ b/racy/racy_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"bldy.build/build"
+	"bldy.build/build/executor"
 )
 
 // regular target
@@ -28,7 +29,7 @@ func (t *testTarget) GetDependencies() []string { return nil }
 
 func (t *testTarget) Hash() []byte { return nil }
 
-func (t *testTarget) Build(*build.Executor) error { return nil }
+func (t *testTarget) Build(*executor.Executor) error { return nil }
 
 func (t *testTarget) Installs() map[string]string { return nil }
 
@@ -45,7 +46,7 @@ func (t *testTargetWithPath) GetDependencies() []string { return nil }
 
 func (t *testTargetWithPath) Hash() []byte { return nil }
 
-func (t *testTargetWithPath) Build(*build.Executor) error { return nil }
+func (t *testTargetWithPath) Build(*executor.Executor) error { return nil }
 
 func (t *testTargetWithPath) Installs() map[string]string { return nil }
 
@@ -62,7 +63,7 @@ func (t *testTargetWithPathAndExt) GetDependencies() []string { return nil }
 
 func (t *testTargetWithPathAndExt) Hash() []byte { return nil }
 
-func (t *testTargetWithPathAndExt) Build(*build.Executor) error { return nil }
+func (t *testTargetWithPathAndExt) Build(*executor.Executor) error { return nil }
 
 func (t *testTargetWithPathAndExt) Installs() map[string]string { return nil }
 

--- a/targets/build/genrule.go
+++ b/targets/build/genrule.go
@@ -8,7 +8,7 @@ import (
 
 	"os"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 	"bldy.build/build/racy"
 )
 
@@ -27,7 +27,7 @@ func (g *GenRule) Hash() []byte {
 	return []byte{}
 }
 
-func (g *GenRule) Build(e *build.Executor) error {
+func (g *GenRule) Build(e *executor.Executor) error {
 	for _, cmd := range g.Commands {
 		strs := strings.Split(cmd, " ")
 

--- a/targets/build/group.go
+++ b/targets/build/group.go
@@ -7,7 +7,7 @@ package build
 import (
 	"path/filepath"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 )
 
 type Group struct {
@@ -21,7 +21,7 @@ func (g *Group) Hash() []byte {
 	return []byte(g.Name)
 }
 
-func (g *Group) Build(e *build.Executor) error {
+func (g *Group) Build(e *executor.Executor) error {
 	return nil
 }
 

--- a/targets/build/template.go
+++ b/targets/build/template.go
@@ -14,7 +14,7 @@ import (
 
 	"sevki.org/lib/prettyprint"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 	"bldy.build/build/racy"
 	"bldy.build/build/targets/cc"
 )
@@ -44,7 +44,7 @@ func (t *Template) Hash() []byte {
 		racy.HashFilesForExt([]string{t.Template}, filepath.Ext(t.Template)))
 }
 
-func (t *Template) Build(e *build.Executor) error {
+func (t *Template) Build(e *executor.Executor) error {
 	t.Vars["_CCVER"] = strings.Split(cc.CCVersion, "\n")[0]
 
 	_, file := filepath.Split(t.Template)

--- a/targets/cc/cbin.go
+++ b/targets/cc/cbin.go
@@ -9,7 +9,7 @@ import (
 
 	"path/filepath"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 	"bldy.build/build/racy"
 )
 
@@ -50,7 +50,7 @@ func (cb *CBin) Hash() []byte {
 	)
 }
 
-func (cb *CBin) Build(e *build.Executor) error {
+func (cb *CBin) Build(e *executor.Executor) error {
 	params := []string{"-c"}
 	params = append(params, cb.CompilerOptions...)
 	params = append(params, cb.Sources...)

--- a/targets/cc/clib.go
+++ b/targets/cc/clib.go
@@ -10,11 +10,10 @@ import (
 	"io"
 	"strings"
 
+	"bldy.build/build/executor"
 	"bldy.build/build/racy"
 
 	"path/filepath"
-
-	"bldy.build/build"
 )
 
 type CLib struct {
@@ -48,7 +47,7 @@ func (cl *CLib) Hash() []byte {
 	)
 }
 
-func (cl *CLib) Build(e *build.Executor) error {
+func (cl *CLib) Build(e *executor.Executor) error {
 	params := []string{"-c"}
 	params = append(params, cl.CompilerOptions...)
 	params = append(params, cl.LinkerOptions...)

--- a/targets/cc/ctest.go
+++ b/targets/cc/ctest.go
@@ -13,7 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 	"bldy.build/build/racy"
 	"sevki.org/lib/prettyprint"
 )
@@ -44,7 +44,7 @@ func (ct *CTest) Hash() []byte {
 	return h.Sum(nil)
 }
 
-func (ct *CTest) Build(e *build.Executor) error {
+func (ct *CTest) Build(e *executor.Executor) error {
 	e.Println(prettyprint.AsJSON(ct))
 	params := []string{"-c"}
 	params = append(params, ct.CompilerOptions...)

--- a/targets/golang/gobuild.go
+++ b/targets/golang/gobuild.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 	"bldy.build/build/racy"
 )
 
@@ -37,7 +37,7 @@ func (g *GoBuild) Hash() []byte {
 	return h.Sum(nil)
 }
 
-func (g *GoBuild) Build(e *build.Executor) error {
+func (g *GoBuild) Build(e *executor.Executor) error {
 	if err := e.Mkdir("_obj/exe"); err != nil {
 		return fmt.Errorf("go mkdir: %s", err.Error())
 	}

--- a/targets/harvey/config.go
+++ b/targets/harvey/config.go
@@ -11,11 +11,10 @@ import (
 	"io"
 	"strings"
 
+	"bldy.build/build/executor"
 	"bldy.build/build/racy"
 
 	"path/filepath"
-
-	"bldy.build/build"
 )
 
 type Config struct {
@@ -55,7 +54,7 @@ func (k *Config) Hash() []byte {
 	return h.Sum(nil)
 }
 
-func (k *Config) Build(e *build.Executor) error {
+func (k *Config) Build(e *executor.Executor) error {
 
 	var rootcodes []string
 	var rootnames []string
@@ -124,7 +123,7 @@ func (k *Config) GetDependencies() []string {
 }
 
 // data2c takes the file at path and creates a C byte array containing it.
-func data2c(name string, path string, e *build.Executor) (string, error) {
+func data2c(name string, path string, e *executor.Executor) (string, error) {
 	var out []byte
 	var in []byte
 	var file *os.File

--- a/targets/harvey/data2c.go
+++ b/targets/harvey/data2c.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"io"
 
-	"io/ioutil"
+	"bldy.build/build/executor"
 
-	"bldy.build/build"
+	"io/ioutil"
 )
 
 type DataToC struct {
@@ -34,7 +34,7 @@ func (dtc *DataToC) Hash() []byte {
 	return []byte{}
 }
 
-func (dtc *DataToC) Build(e *build.Executor) error {
+func (dtc *DataToC) Build(e *executor.Executor) error {
 
 	inFile, err := e.Open(dtc.Bin)
 	if err != nil {

--- a/targets/harvey/elf2c.go
+++ b/targets/harvey/elf2c.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 )
 
 type ElfToC struct {
@@ -41,7 +41,7 @@ func (etc *ElfToC) Hash() []byte {
 	return []byte{}
 }
 
-func (etc *ElfToC) Build(e *build.Executor) error {
+func (etc *ElfToC) Build(e *executor.Executor) error {
 	fileName := ""
 
 	if xf, err := e.Open(etc.Elf); err != nil {

--- a/targets/harvey/man.go
+++ b/targets/harvey/man.go
@@ -10,7 +10,7 @@ import (
 
 	"os"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 	"bldy.build/build/racy"
 )
 
@@ -30,7 +30,7 @@ func (mp *ManPage) Hash() []byte {
 	return []byte{}
 }
 
-func (mp *ManPage) Build(e *build.Executor) error {
+func (mp *ManPage) Build(e *executor.Executor) error {
 	for _, m := range mp.Sources {
 		params := []string{"<"}
 		params = append(params, m)

--- a/targets/harvey/mksys.go
+++ b/targets/harvey/mksys.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"text/template"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 	"bldy.build/build/racy"
 	"sevki.org/lib/prettyprint"
 )
@@ -136,7 +136,7 @@ func (mkSys *MkSys) GetDependencies() []string {
 	return mkSys.Dependencies
 }
 
-func (mkSys *MkSys) Build(e *build.Executor) error {
+func (mkSys *MkSys) Build(e *executor.Executor) error {
 
 	e.Println(prettyprint.AsJSON(mkSys))
 

--- a/targets/harvey/move.go
+++ b/targets/harvey/move.go
@@ -3,9 +3,9 @@ package harvey
 import (
 	"crypto/sha1"
 
-	"io"
+	"bldy.build/build/executor"
 
-	"bldy.build/build"
+	"io"
 )
 
 type Move struct {
@@ -20,7 +20,7 @@ func (m *Move) Hash() []byte {
 	return h.Sum(nil)
 }
 
-func (m *Move) Build(e *build.Executor) error {
+func (m *Move) Build(e *executor.Executor) error {
 	return nil
 }
 

--- a/targets/harvey/objcopy.go
+++ b/targets/harvey/objcopy.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"path/filepath"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 	"bldy.build/build/project"
 )
 
@@ -45,7 +45,7 @@ func Copier() string {
 		return fmt.Sprintf("%s%s", tpfx, "objcopy")
 	}
 }
-func (oc *ObjCopy) Build(e *build.Executor) error {
+func (oc *ObjCopy) Build(e *executor.Executor) error {
 	params := []string{}
 	params = append(params, "-I")
 	params = append(params, oc.In)

--- a/targets/harvey/oldbuild.go
+++ b/targets/harvey/oldbuild.go
@@ -11,9 +11,9 @@ import (
 	"os"
 	"path"
 
-	"github.com/nu7hatch/gouuid"
+	"bldy.build/build/executor"
 
-	"bldy.build/build"
+	"github.com/nu7hatch/gouuid"
 )
 
 type OldBuild struct {
@@ -40,7 +40,7 @@ func (s *OldBuild) Hash() []byte {
 func oldbuild() string {
 	return path.Join(os.Getenv("HARVEY"), "util/build")
 }
-func (s *OldBuild) Build(e *build.Executor) error {
+func (s *OldBuild) Build(e *executor.Executor) error {
 	params := []string{s.Package}
 
 	if err := e.Exec(oldbuild(), nil, params); err != nil {

--- a/targets/harvey/qemu.go
+++ b/targets/harvey/qemu.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 )
 
 type Qemu struct {
@@ -46,7 +46,7 @@ func (q *Qemu) Hash() []byte {
 	return []byte{}
 }
 
-func (q *Qemu) Build(e *build.Executor) error {
+func (q *Qemu) Build(e *executor.Executor) error {
 	system := "qemu-system-x86_64"
 	params := []string{"-s"} // shorthand for -gdb tcp::1234
 

--- a/targets/harvey/sed.go
+++ b/targets/harvey/sed.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"os/exec"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 )
 
 type Sed struct {
@@ -35,7 +35,7 @@ func (s *Sed) Hash() []byte {
 	return []byte{}
 }
 
-func (s *Sed) Build(e *build.Executor) error {
+func (s *Sed) Build(e *executor.Executor) error {
 	params := s.Args
 	if s.Script != "" {
 		params = append(params, "-f", s.Script)

--- a/targets/harvey/strip.go
+++ b/targets/harvey/strip.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"path/filepath"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 	"bldy.build/build/project"
 )
 
@@ -41,7 +41,7 @@ func Stripper() string {
 		return fmt.Sprintf("%s%s", tpfx, "strip")
 	}
 }
-func (s *Strip) Build(e *build.Executor) error {
+func (s *Strip) Build(e *executor.Executor) error {
 	params := []string{"-o"}
 	params = append(params, s.Name)
 	params = append(params, filepath.Join("bin", split(s.Dependencies[0], ":")))

--- a/targets/harvey/usb.go
+++ b/targets/harvey/usb.go
@@ -13,7 +13,7 @@ import (
 	"log"
 	"text/template"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 	"bldy.build/build/racy"
 )
 
@@ -56,7 +56,7 @@ func (s *USB) Installs() map[string]string {
 	return installs
 }
 
-func (s *USB) Build(e *build.Executor) error {
+func (s *USB) Build(e *executor.Executor) error {
 	f, err := e.Open(s.Conf)
 	if err != nil {
 		return err

--- a/targets/yacc/yacc.go
+++ b/targets/yacc/yacc.go
@@ -18,7 +18,7 @@ import (
 
 	"fmt"
 
-	"bldy.build/build"
+	"bldy.build/build/executor"
 	"bldy.build/build/internal"
 	"bldy.build/build/racy"
 )
@@ -56,7 +56,7 @@ func (y *Yacc) Hash() []byte {
 	return h.Sum(nil)
 }
 
-func (y *Yacc) Build(e *build.Executor) error {
+func (y *Yacc) Build(e *executor.Executor) error {
 
 	params := []string{}
 	params = append(params, y.YaccOptions...)


### PR DESCRIPTION
this is done in preperation for namespaced executors

Signed-off-by: Sevki <s@sevki.org>